### PR TITLE
fix: fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The details of evaluation are as follows:
   </tr>
 </table>
 
-### Soeech-to-text Translation
+### Speech-to-text Translation
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
There was a small typo in the README.md file. The typo has been corrected from "Soeech-to-text Translation" to "Speech-to-text Translation"